### PR TITLE
Fix syntax in the README code sample

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 ```go
 template, err := liquid.ParseString("hello {{ name | upcase }}", nil)
 if err != nil { panic(err) }
-data := map[string]interface{
+data := map[string]interface{}{
   "name": "leto",
 }
 writer := new(bytes.Buffer)


### PR DESCRIPTION
Under Go 1.4 the `map[string]interface { ... }` construct doesn't compile, adding `{}` to `interface` fixes it.